### PR TITLE
Allow no inelastic collisions

### DIFF
--- a/bolos/solver.py
+++ b/bolos/solver.py
@@ -136,15 +136,6 @@ class BoltzmannSolver(object):
 
         # A dictionary with target_name -> target
         self.target = {}
-
-        self.n_processes = {"ELASTIC": 0,
-                            "EFFECTIVE": 0,
-                            "MOMENTUM": 0,
-                            "ATTACHMENT": 0,
-                            "EXCITATION": 0,
-                            "WEIGHTED_ELASTIC": 0,
-                            "INELASTIC": 0
-                            }
     
     def _get_grid(self):
         return self._grid
@@ -287,8 +278,6 @@ class BoltzmannSolver(object):
             self.target[proc.target_name] = target
 
         target.add_process(proc)
-
-        self._count_process(proc)
 
         return proc
 
@@ -584,16 +573,6 @@ class BoltzmannSolver(object):
         logging.error("Convergence failed")
 
         raise ConvergenceError()
-
-
-    def _count_process(self, process: Process):
-        
-        self.n_processes[process.kind] += 1
-
-        inelastic_processes = ["IONIZATION", "ATTACHMENT", "EXCITATION"]
-
-        if process.kind in inelastic_processes:
-            self.n_processes["INELASTIC"] += 1
 
 
     def _linsystem(self, F):

--- a/bolos/solver.py
+++ b/bolos/solver.py
@@ -136,6 +136,8 @@ class BoltzmannSolver(object):
 
         # A dictionary with target_name -> target
         self.target = {}
+
+        print("HEEEEEEEEEEEELP")
         
     def _get_grid(self):
         return self._grid

--- a/bolos/solver.py
+++ b/bolos/solver.py
@@ -669,7 +669,6 @@ class BoltzmannSolver(object):
 
 
     def _PQ(self, F0, reactions=None):
-        print("PQing HARD")
         PQ = sparse.csr_matrix((self.n, self.n))
 
         g = self._g(F0)

--- a/bolos/solver.py
+++ b/bolos/solver.py
@@ -689,9 +689,9 @@ class BoltzmannSolver(object):
         data, rows, cols = (np.hstack(x) for x in (data, rows, cols))
         PQ = sparse.coo_matrix((data, (rows, cols)),
                             shape=(self.n, self.n))
-        else:
+        #else:
             # There are no inelastic collisions
-            PQ = sparse.coo_matrix((self.n, self.n))
+        #    PQ = sparse.coo_matrix((self.n, self.n))
 
         return PQ
 

--- a/bolos/solver.py
+++ b/bolos/solver.py
@@ -681,9 +681,10 @@ class BoltzmannSolver(object):
 
         g = self._g(F0)
         if reactions is None:
-            reactions = list(self.iter_inelastic())
-
-        print(self.n_processes)
+            if self.n_processes["INELASTIC"] == 0:
+                return sparse.coo_matrix((self.n, self.n))
+            else:
+                reactions = list(self.iter_inelastic())
 
         data = []
         rows = []
@@ -699,9 +700,6 @@ class BoltzmannSolver(object):
         data, rows, cols = (np.hstack(x) for x in (data, rows, cols))
         PQ = sparse.coo_matrix((data, (rows, cols)),
                             shape=(self.n, self.n))
-        #else:
-            # There are no inelastic collisions
-        #    PQ = sparse.coo_matrix((self.n, self.n))
 
         return PQ
 

--- a/bolos/solver.py
+++ b/bolos/solver.py
@@ -656,26 +656,32 @@ class BoltzmannSolver(object):
 
 
     def _PQ(self, F0, reactions=None):
+        print("PQing HARD")
         PQ = sparse.csr_matrix((self.n, self.n))
 
         g = self._g(F0)
         if reactions is None:
             reactions = list(self.iter_inelastic())
 
-        data = []
-        rows = []
-        cols = []
-        for t, k in reactions:
-            r = t.density * GAMMA * k.scatterings(g, self.cenergy)
-            in_factor = k.in_factor
-            
-            data.extend([in_factor * r, -r])
-            rows.extend([k.i, k.j])
-            cols.extend([k.j, k.j])
+        if len(reactions) > 0:
 
-        data, rows, cols = (np.hstack(x) for x in (data, rows, cols))
-        PQ = sparse.coo_matrix((data, (rows, cols)),
-                              shape=(self.n, self.n))
+            data = []
+            rows = []
+            cols = []
+            for t, k in reactions:
+                r = t.density * GAMMA * k.scatterings(g, self.cenergy)
+                in_factor = k.in_factor
+                
+                data.extend([in_factor * r, -r])
+                rows.extend([k.i, k.j])
+                cols.extend([k.j, k.j])
+
+            data, rows, cols = (np.hstack(x) for x in (data, rows, cols))
+            PQ = sparse.coo_matrix((data, (rows, cols)),
+                                shape=(self.n, self.n))
+        else:
+            # There are no inelastic collisions
+            PQ = sparse.coo_matrix((self.n, self.n))
 
         return PQ
 

--- a/bolos/solver.py
+++ b/bolos/solver.py
@@ -137,11 +137,13 @@ class BoltzmannSolver(object):
         # A dictionary with target_name -> target
         self.target = {}
 
-        self.n_processes = {"elastic": 0,
-                            "inelastic": 0,
-                            "ionization": 0,
-                            "attachment": 0,
-                            "excitation": 0
+        self.n_processes = {"ELASTIC": 0,
+                            "EFFECTIVE": 0,
+                            "MOMENTUM": 0,
+                            "ATTACHMENT": 0,
+                            "EXCITATION": 0,
+                            "WEIGHTED_ELASTIC": 0,
+                            "INELASTIC": 0
                             }
     
     def _get_grid(self):
@@ -585,8 +587,14 @@ class BoltzmannSolver(object):
 
 
     def _count_process(self, process: Process):
+        
+        self.n_processes[process.kind] += 1
 
-        print(process.kind)
+        inelastic_processes = ["IONIZATION", "ATTACHMENT", "EXCITATION"]
+
+        if process.kind in inelastic_processes:
+            self.n_processes["INELASTIC"] += 1
+
 
     def _linsystem(self, F):
         Q = self._PQ(F)
@@ -674,6 +682,8 @@ class BoltzmannSolver(object):
         g = self._g(F0)
         if reactions is None:
             reactions = list(self.iter_inelastic())
+
+        print(self.n_processes)
 
         data = []
         rows = []

--- a/samples/bolsig.py
+++ b/samples/bolsig.py
@@ -103,7 +103,7 @@ def main():
         bolos[i, :] = [bsolver.rate(f2, p) for p in processes]
     
     for k, p in enumerate(processes):
-        print "%.3d:  %-40s   %s eV" % (k, p, p.threshold or 0.0)
+        print("%.3d:  %-40s   %s eV" % (k, p, p.threshold or 0.0))
         
         plt.clf()
         plt.figure(figsize=(8, 8))

--- a/samples/single.py
+++ b/samples/single.py
@@ -89,15 +89,15 @@ def main():
     
     # You can also iterate over all processes or over processes of a certain
     # type.
-    print "\nREACTION RATES:\n"
+    print("\nREACTION RATES:\n")
     for t, p in bsolver.iter_all():
-        print "%-40s   %.3e m^3/s" % (str(p), bsolver.rate(f1, p))
+        print("%-40s   %.3e m^3/s" % (str(p), bsolver.rate(f1, p)))
 
     # Calculate the mobility and diffusion.
-    print "\nTRANSPORT PARAMETERS:\n"
-    print "mobility * N   = %.3e  1/m/V/s" % bsolver.mobility(f1)
-    print "diffusion * N  = %.3e  1/m/s" % bsolver.diffusion(f1)
-    print "average energy = %.3e  eV" % bsolver.mean_energy(f1)
+    print("\nTRANSPORT PARAMETERS:\n")
+    print("mobility * N   = %.3e  1/m/V/s" % bsolver.mobility(f1))
+    print("diffusion * N  = %.3e  1/m/s" % bsolver.diffusion(f1))
+    print("average energy = %.3e  eV" % bsolver.mean_energy(f1))
 
     import pylab
     pylab.plot(bsolver.grid.c, f1)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages.
-    packages=find_packages("bolos", exclude=["contrib", "docs", "tests*"]),
+    packages=find_packages(exclude=["contrib", "docs", "tests*"]),
 
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed.

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages.
-    packages=find_packages(exclude=["contrib", "docs", "tests*"]),
+    packages=find_packages("bolos", exclude=["contrib", "docs", "tests*"]),
 
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed.


### PR DESCRIPTION
Problem: When using an LXCat file with ONLY an elastic collision the solver will error out on the `hstack` function in `_PQ`. This is due to the fact that sometimes `_PQ` is called without setting the parameter `reactions`. This parameter will then be set to inelastic collisions, but no check has been made for the case when there are no inelastic collisions.

Following plots show the electron velocity W, reduced diffusion coeff, and mean energy of Maxwell type testsystem (constant momentum transfer collision frequency). 

The labels are:
Maxwell = The changes proposed in this MR with an LXCat file containing ONLY the elastic collision cs
MaxwellAttachment = The changes proposed in this MR with an LXCat file containing BOTH elastic collision cs AND 0 attachment cs to add a non participating inelastic process.
MaxwellOld = The previous version with an LXCat file containing BOTH elastic collision cs AND 0 attachment cs to add a non participating inelastic process.

The results show that all 3 methods produce the exact same results so that the proposed changes in this MR do not change results, but only adds flexibility by allowing the use of a single elastic cs and no inelastic cs.

![Screenshot from 2021-05-26 15-18-38](https://user-images.githubusercontent.com/8082286/119666551-c2762980-be35-11eb-80bd-1c9eb910b5b3.png)
![Screenshot from 2021-05-26 15-18-48](https://user-images.githubusercontent.com/8082286/119666559-c4d88380-be35-11eb-9bad-a3bcad1a5da7.png)
![Screenshot from 2021-05-26 15-18-59](https://user-images.githubusercontent.com/8082286/119666571-c73add80-be35-11eb-9c5d-d05bc8715daa.png)
